### PR TITLE
Include merge_group to workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - 'frontend/**'
-
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   prettier:


### PR DESCRIPTION
## Proposed Changes

- Fixes merge queue. In the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group), it specifies that we need include merge_group to handle GitHub's merge queue feature
