### PR TITLE
Run aws deploy workflow on pull request

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -24,6 +24,7 @@ jobs:
         working-directory: frontend/
       
       - name: Build
+        working-directory: frontend/
         run: npm run build
 
       - name: Deploy to S3

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
       - main
+  pull_request:
+    branches:
+      - dev
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy to S3
         uses: reggionick/s3-deploy@v4
         with:
-          folder: build
+          folder: frontend/build
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Deploy to S3
         uses: reggionick/s3-deploy@v4
         with:
-          folder: frontend/build
+          folder: frontend/out
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -28,14 +25,12 @@ jobs:
         run: npm run build
 
       - name: Deploy to S3
-        uses: reggionick/s3-deploy@v4
+        uses: jakejarvis/s3-sync-action@master
         with:
-          folder: frontend/out
-          bucket: ${{ secrets.S3_BUCKET }}
-          bucket-region: ${{ secrets.S3_BUCKET_REGION }}
-          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          invalidation: /
-          delete-removed: true
-          no-cache: true
-          private: true
-          files-to-include: '{.*/**,**}'
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'ca-central-1'
+          SOURCE_DIR: 'public'

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -33,4 +33,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
-          SOURCE_DIR: 'public'
+          SOURCE_DIR: 'frontend/out'


### PR DESCRIPTION
## Proposed Changes

- Utilizes the [S3-deploy](https://github.com/marketplace/actions/s3-deploy) github action to deploy the frontend build to the S3 bucket.
- Moved away from previous Gh action due to messages about deprecated AWS SDK 2 (this version also seems much more simplified - no need to specify cloudfront distribution ID)
