### PR TITLE
Add timezone to regenerate embeddings

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function Home() {
               window.open(
                 "https://forumai.me/auth/signin",
                 "_blank",
-                "noopener,noreferrer"
+                "noopener,noreferrer",
               )
             }
           >
@@ -55,7 +55,7 @@ export default function Home() {
               window.open(
                 "https://github.com/ubclaunchpad/forum",
                 "_blank",
-                "noopener,noreferrer"
+                "noopener,noreferrer",
               )
             }
           >
@@ -270,7 +270,7 @@ export default function Home() {
                   window.open(
                     "https://forumai.me/auth/signin",
                     "_blank",
-                    "noopener,noreferrer"
+                    "noopener,noreferrer",
                   )
                 }
               >

--- a/frontend/src/components/course/documents/DocumentOptionsPopover.tsx
+++ b/frontend/src/components/course/documents/DocumentOptionsPopover.tsx
@@ -238,7 +238,10 @@ export default function DocumentOptionsPopover({
                 {metadata.has_embeddings && (
                   <div className="">
                     Last updated:{" "}
-                    {new Date(metadata.last_updated!).toLocaleString()}
+                    {new Date(metadata.last_updated!).toLocaleString("en-US", {
+                      timeZone: "America/Vancouver",
+                      timeZoneName: "short",
+                    })}
                   </div>
                 )}
               </li>

--- a/frontend/src/components/posts/PostEmbeddingPopoverChip.tsx
+++ b/frontend/src/components/posts/PostEmbeddingPopoverChip.tsx
@@ -169,7 +169,10 @@ export default function PostEmbeddingPopoverChip({ post }: { post: Post }) {
               {metadata.has_embeddings && (
                 <div className="">
                   Last updated:{" "}
-                  {new Date(metadata.last_updated!).toLocaleString()}
+                  {new Date(metadata.last_updated!).toLocaleString("en-US", {
+                    timeZone: "America/Vancouver",
+                    timeZoneName: "short",
+                  })}
                 </div>
               )}
             </li>

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -10,7 +10,7 @@ const Card = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-lg border b text-card-foreground shadow-sm dark:text-gray-100 dark:border-gray-700",
-      className
+      className,
     )}
     {...props}
   />
@@ -23,7 +23,10 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6 dark:text-gray-100", className)}
+    className={cn(
+      "flex flex-col space-y-1.5 p-6 dark:text-gray-100",
+      className,
+    )}
     {...props}
   />
 ));
@@ -37,7 +40,7 @@ const CardTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-2xl font-semibold leading-none tracking-tight dark:text-gray-100",
-      className
+      className,
     )}
     {...props}
   />
@@ -50,7 +53,10 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground dark:text-gray-300", className)}
+    className={cn(
+      "text-sm text-muted-foreground dark:text-gray-300",
+      className,
+    )}
     {...props}
   />
 ));
@@ -60,7 +66,11 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0 dark:text-gray-100", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn("p-6 pt-0 dark:text-gray-100", className)}
+    {...props}
+  />
 ));
 CardContent.displayName = "CardContent";
 


### PR DESCRIPTION
## Proposed Changes

- Add timezone to regen embeddings.
   - Currently it only displays time in UTC, but maybe in the future, we could let users to customize their time zone in profile section.
<img width="317" alt="Screenshot 2025-02-22 at 2 41 56 PM" src="https://github.com/user-attachments/assets/81b157cc-71ab-4fcb-9a0c-93469215df24" />

The current time should show 2:27 PM PST.

- Rerun prettier to fix linting issues
