### PR TITLE
Add trigger to delete file in storage when deleting entry in files table

### DIFF
--- a/server/supabase/config.toml
+++ b/server/supabase/config.toml
@@ -42,8 +42,9 @@ default_pool_size = 20
 # Maximum number of client connections allowed.
 max_client_conn = 100
 
-# [db.vault]
+[db.vault]
 # secret_key = "env(SECRET_VALUE)"
+service_role_key = "env(SUPABASE_SERVICE_ROLE_KEY)"
 
 [db.migrations]
 # Specifies an ordered list of schema files that describe your database.

--- a/server/supabase/functions/tests/utils/fileManager_test.ts
+++ b/server/supabase/functions/tests/utils/fileManager_test.ts
@@ -2,8 +2,9 @@ import { afterEach, before, beforeEach, describe, it } from "jsr:@std/testing/bd
 import {  supa } from "../../_shared/db.ts";
 import { DEFAULT_FILE_MANAGER_OPTIONS, FileManager, fileManager } from "../../_shared/utils/fileManager.ts";
 import { assertEquals } from "jsr:@std/assert/equals";
-import { DuplicateBucketError, StorageBucketNotFoundError } from "../../_shared/errors.ts";
-import { assertRejects } from "jsr:@std/assert";
+import { DuplicateBucketError, StorageBucketNotFoundError, InputValidationError } from "../../_shared/errors.ts";
+import { assertNotEquals, assertRejects } from "jsr:@std/assert";
+import { setTimeout } from "node:timers/promises";
 
 describe("File Manager", () => {
     let fileManagerInstance: FileManager;
@@ -96,5 +97,58 @@ describe("File Manager", () => {
     describe("When handling files"), () => {
 
     }
+
+    describe("Test delete trigger", () => {
+        const filePath = "testdelete.png";
+        const bucket = "test";
+        const fileId = "01f49131-63dc-4e66-9fbf-ea9fa152b13b";
+
+        it("should upload a file", async () => {    
+            const bucketName = "test";
+            await fileManagerInstance.buckets.createBucket(bucketName, {
+                public: true
+            });
+            const file = new File(["test"], "testdelete.png", { type: "image/png" });
+            const uploadedFile = await fileManagerInstance.buckets.usingBucket(bucketName).uploadFile(file);
+            assertEquals(uploadedFile.name, file.name);
+        });
+
+        it("should add row to files table", async () => {
+            const newFile = {
+                "id": fileId,
+                "name": "testFile",
+                "type": "image/png",
+                "size": 1200,
+                "path": filePath,
+                "bucket": bucket
+            };
+            const { data: file, error: error } = await supa.from("files").insert({...newFile}).select().single();
+            if (error) {
+                throw new InputValidationError("Failed to create file entry: " + error.message);
+            }
+
+            await setTimeout(1000);
+
+            assertEquals(file.id, fileId);
+        });
+        it("should delete entry from files table", async () => {
+            const { error } = await supa.from("files").delete().eq('id', fileId);
+
+            if (error) {
+                throw new Error("failed to delete entry: " + error.message);
+            }
+        });
+        it("file should be deleted from storage", async () => {
+            const {data, error} = await supa.storage.from(bucket).list();
+            
+            if (error) {
+                throw new Error("failed to delete entry: " + error.message);
+            }
+
+            for (const file of data) {
+                assertNotEquals(file.name, filePath);
+            }
+        });
+    });
 });
     

--- a/server/supabase/migrations/1741828112535_ai_setup.sql
+++ b/server/supabase/migrations/1741828112535_ai_setup.sql
@@ -26,6 +26,7 @@ with
 
 -- Schema for utility functions
 create schema util;
+grant USAGE on schema util to service_role;
 
 -- Utility function to get the Supabase project URL (required for Edge Functions)
 create function util.project_url()

--- a/server/supabase/migrations/1741934397000_files_table.sql
+++ b/server/supabase/migrations/1741934397000_files_table.sql
@@ -1,4 +1,41 @@
+create extension if not exists pg_net
+with
+  schema extensions;
 
+create or replace function delete_file_from_storage()
+returns trigger as $$
+declare 
+    request_id BIGINT;
+    file_path TEXT;
+    bucket TEXT;
+    service_role_key TEXT;
+    request_url TEXT;
+    request_headers JSONB;
+begin 
+    file_path := OLD.path;
+    bucket := OLD.bucket;
+    
+    -- Fetch service role key
+    -- requires service_role_key to be added to vault, didn't add here to avoid leaking key through github
+    SELECT decrypted_secret INTO service_role_key 
+    FROM vault.decrypted_secrets 
+    WHERE name = 'service_role_key';
+
+    -- Construct request URL
+        request_url := util.project_url() || '/storage/v1/object/' || bucket || '/' || file_path;
+    -- Construct header
+    request_headers := jsonb_build_object('Authorization', service_role_key);
+
+    net.http_delete(
+        request_url,
+        '{}'::jsonb,  -- No query params
+        request_headers,
+        5000  -- Timeout in ms
+    )
+
+    return OLD;
+end;
+$$ language plpgsql;
 
 
 CREATE TABLE files (
@@ -13,5 +50,7 @@ CREATE TABLE files (
 );
 
 
-
+CREATE TRIGGER on_file_delete
+AFTER DELETE ON files
+FOR EACH ROW EXECUTE FUNCTION delete_file_from_storage();
 

--- a/server/supabase/migrations/1741934397000_files_table.sql
+++ b/server/supabase/migrations/1741934397000_files_table.sql
@@ -22,16 +22,16 @@ begin
     WHERE name = 'service_role_key';
 
     -- Construct request URL
-        request_url := util.project_url() || '/storage/v1/object/' || bucket || '/' || file_path;
+    request_url := util.project_url() || '/storage/v1/object/' || bucket || '/' || file_path;
     -- Construct header
     request_headers := jsonb_build_object('Authorization', service_role_key);
 
-    net.http_delete(
+    perform net.http_delete(
         request_url,
         '{}'::jsonb,  -- No query params
         request_headers,
         5000  -- Timeout in ms
-    )
+    );
 
     return OLD;
 end;


### PR DESCRIPTION
Added function to delete file in storage bucket, after delete in public.files has occurred. 
Added service_role_key to vault secrets.  (using config.toml)

Added tests as well

Had to add `grant USAGE on schema util to service_role;` to address encountering the error below whenever performing bucket operations

```
error: {
  code: "42501",
  details: null,
  hint: null,
  message: "permission denied for schema util"
}
```

closes #344 
